### PR TITLE
Update location of module, go version and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This tool merges require blocks in `go.mod` files since [`go mod tidy` doesn't d
 ## Installation
 
 ```sh
-go install go.abhijithota.me/modfmt@latest
+go install github.com/abhijit-hota/modfmt@latest
 ```
 
 ## Usage

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module go.abhijithota.me/modfmt
+module github.com/abhijit-hota/modfmt
 
-go 1.22.4
+go 1.24.1
 
-require golang.org/x/mod v0.18.0
+require golang.org/x/mod v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 golang.org/x/mod v0.18.0 h1:5+9lSbEzPSdWkH32vYPBwEpX8KwDbM52Ud9xBUvNlb0=
 golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
+golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=


### PR DESCRIPTION
Updates the module path to Github. This will help prevent concerns about account take-overs of the existing domain.

Also updates to latest version of go, and updated the `golang.org/x/mod` to latest.