### PR TITLE
Add check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ In your Go project root, run:
 modfmt --in-place
 ```
 
+You can also use the `--check` flag to check if the `go.mod` file is already formatted. This command will exit with a 
+non-zero status code if the file needs formatting.
+```sh
+modfmt --check
+```
+
 ## Limitations
 
 I hacked this tool together using the official parser in less than 2 hours and unsurprisingly there are a few drawbacks with this:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ In your Go project root, run:
 modfmt --in-place
 ```
 
-You can also use the `--check` flag to check if the `go.mod` file is already formatted. This command will exit with a 
-non-zero status code if the file needs formatting.
+The `--check` command will override other flags, and will instead return a non-zero exit code if the `go.mod` file is
+not formatted, or zero if it is already formatted. This is useful for validating `go.mod` files in CI pipelines.
 ```sh
 modfmt --check
 ```

--- a/main.go
+++ b/main.go
@@ -22,13 +22,26 @@ func run() error {
 	}
 
 	var inplace bool
+	var check bool
+
 	flag.BoolVar(&inplace, "in-place", false, "replace the contents of go.mod with the updated contents")
 	flag.BoolVar(&inplace, "i", false, "replace the contents of go.mod with the updated contents")
+
+	flag.BoolVar(&check, "check", false, "check if the go.mod file is formatted correctly")
+
 	flag.Parse()
+
+	if inplace && check {
+		return fmt.Errorf("cannot use both --in-place and --check flags simultaneously")
+	}
 
 	// check if we want to replace the contents of go.mod
 	if inplace {
 		return updateInplace(gomodName, updatedContents)
+	}
+
+	if check {
+		return checkContents(gomodName, updatedContents)
 	}
 
 	fmt.Println(string(updatedContents))
@@ -46,6 +59,22 @@ func updateInplace(modLocation string, updatedContents []byte) error {
 	if err = os.WriteFile(modLocation, updatedContents, info.Mode()); err != nil {
 		return fmt.Errorf("failed to write updated go.mod: %w", err)
 	}
+
+	return nil
+}
+
+func checkContents(modLocation string, updatedContents []byte) error {
+	// get current contents of go.mod
+	contents, err := os.ReadFile(modLocation)
+	if err != nil {
+		return fmt.Errorf("failed to read go.mod: %w", err)
+	}
+
+	if string(contents) != string(updatedContents) {
+		return fmt.Errorf("go.mod contents are not formatted correctly")
+	}
+
+	fmt.Println("go.mod is formatted correctly")
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -31,19 +31,13 @@ func run() error {
 
 	flag.Parse()
 
-	if inplace && check {
-		return fmt.Errorf("cannot use both --in-place and --check flags simultaneously")
-	}
-
-	// check if we want to replace the contents of go.mod
-	if inplace {
-		return updateInplace(gomodName, updatedContents)
-	}
-
 	if check {
 		return checkContents(gomodName, updatedContents)
 	}
 
+	if inplace {
+		return updateInplace(gomodName, updatedContents)
+	}
 	fmt.Println(string(updatedContents))
 	return nil
 }


### PR DESCRIPTION
Add `--check` that returns a non-zero exit code if the file is not correctly formatted.

We will use this for running the command in Github actions, to return an error if mod files are committed when incorrectly formatted.